### PR TITLE
[NONMODULAR]Crusherborg

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -157,8 +157,8 @@
 	if(.)
 		for(var/obj/item/pickaxe/drill/cyborg/D in R.module)
 			R.module.remove_module(D, TRUE)
-		for(var/obj/item/shovel/S in R.module)
-			R.module.remove_module(S, TRUE)
+		//for(var/obj/item/shovel/S in R.module)
+		//	R.module.remove_module(S, TRUE)
 
 		var/obj/item/pickaxe/drill/cyborg/diamond/DD = new /obj/item/pickaxe/drill/cyborg/diamond(R.module)
 		R.module.basic_modules += DD

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -525,7 +525,8 @@
 		/obj/item/borg/sight/meson,
 		/obj/item/storage/bag/ore/cyborg,
 		/obj/item/pickaxe/drill/cyborg,
-		/obj/item/twohanded/kinetic_crusher, // EROS/SPLURT edit. Replacing the shovel with the Kinetic Crusher.
+		/obj/item/shovel,
+		/obj/item/twohanded/kinetic_crusher, // EROS/SPLURT edit.
 		/obj/item/crowbar/cyborg,
 		/obj/item/weldingtool/mini,
 		/obj/item/borg/cyborghug,

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -525,7 +525,7 @@
 		/obj/item/borg/sight/meson,
 		/obj/item/storage/bag/ore/cyborg,
 		/obj/item/pickaxe/drill/cyborg,
-		/obj/item/shovel,
+		/obj/item/twohanded/kinetic_crusher, // EROS/SPLURT edit. Replacing the shovel with the Kinetic Crusher.
 		/obj/item/crowbar/cyborg,
 		/obj/item/weldingtool/mini,
 		/obj/item/borg/cyborghug,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds the crusher to the Minerborg's arsenal, prevents the diamond drill upgrade from removing the shovel.

## Why It's Good For The Game

Allows the minerborgs have an extended option for mining and self-defense against hostile fauna and butcher them easier than the shovel can't.

## Changelog
:cl:
add: Crusher for Minerborg
code: The Diamond Mining Drill Upgrade shouldn't remove the shovel anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
